### PR TITLE
 Made jackson-friendly empty constructors

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSingleSampleStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSingleSampleStats.java
@@ -5,7 +5,8 @@ package org.opencb.biodata.models.variant.stats;
  * User: aaleman
  * Date: 8/29/13
  * Time: 10:21 AM
- * To change this template use File | Settings | File Templates.
+ *
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
  */
 public class VariantSingleSampleStats {
 
@@ -15,10 +16,7 @@ public class VariantSingleSampleStats {
     private int numHomozygous;
 
     VariantSingleSampleStats() {
-        this.id = null;
-        this.numMendelianErrors = 0;
-        this.numMissingGenotypes = 0;
-        this.numHomozygous = 0;
+        this(null);
     }
 
     public VariantSingleSampleStats(String id) {

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSingleSampleStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSingleSampleStats.java
@@ -14,6 +14,12 @@ public class VariantSingleSampleStats {
     private int numMissingGenotypes;
     private int numHomozygous;
 
+    VariantSingleSampleStats() {
+        this.id = null;
+        this.numMendelianErrors = 0;
+        this.numMissingGenotypes = 0;
+        this.numHomozygous = 0;
+    }
 
     public VariantSingleSampleStats(String id) {
         this.id = id;

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
@@ -21,11 +21,7 @@ public class VariantSourceStats {
     private Map<String, VariantSingleSampleStats> samplesStats;
 
     VariantSourceStats() {
-        fileId = null;
-        studyId = null;
-        sampleNames = new ArrayList<>();
-        fileStats = new VariantGlobalStats();
-        samplesStats = new LinkedHashMap<>();
+        this(null, null);
     }
 
     public VariantSourceStats(String fileId, String studyId) {

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
@@ -1,9 +1,7 @@
 package org.opencb.biodata.models.variant.stats;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.opencb.biodata.models.feature.AllelesCode;
 import org.opencb.biodata.models.feature.Genotype;
 import org.opencb.biodata.models.pedigree.Pedigree;
@@ -12,6 +10,7 @@ import org.opencb.biodata.models.variant.Variant;
 
 /**
  * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
  */
 public class VariantSourceStats {
 
@@ -21,7 +20,14 @@ public class VariantSourceStats {
     private VariantGlobalStats fileStats;
     private Map<String, VariantSingleSampleStats> samplesStats;
 
-    
+    VariantSourceStats() {
+        fileId = null;
+        studyId = null;
+        sampleNames = new ArrayList<>();
+        fileStats = new VariantGlobalStats();
+        samplesStats = new LinkedHashMap<>();
+    }
+
     public VariantSourceStats(String fileId, String studyId) {
         this.fileId = fileId;
         this.studyId = studyId;
@@ -109,5 +115,12 @@ public class VariantSourceStats {
             }
         }
     }
-    
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public String getStudyId() {
+        return studyId;
+    }
 }


### PR DESCRIPTION
Constructors from:
* VariantSingleSampleStats
* VariantSourceStats

In order to allow serializing statistics in opencga-storage.