### PR TITLE
models: provisional fix & log message for wrong stats.

### DIFF
--- a/biodata-models/pom.xml
+++ b/biodata-models/pom.xml
@@ -34,6 +34,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
@@ -7,6 +7,8 @@ import org.opencb.biodata.models.feature.Genotype;
 import org.opencb.biodata.models.pedigree.Pedigree;
 import org.opencb.biodata.models.variant.VariantSourceEntry;
 import org.opencb.biodata.models.variant.Variant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
@@ -50,14 +52,22 @@ public class VariantSourceStats {
     }
 
     public void updateFileStats(List<Variant> variants) {
+        int incompleteVariantStats = 0;
         for (Variant v : variants) {
             VariantSourceEntry file = v.getSourceEntry(fileId, studyId);
             if (file == null) {
                 // The variant is not contained in this file
                 continue;
             }
-            
-            fileStats.update(file.getStats());
+            try {
+                fileStats.update(file.getStats());
+            } catch (NullPointerException e) {
+                incompleteVariantStats++;
+            }
+        }
+        if (incompleteVariantStats != 0) {
+            Logger logger = LoggerFactory.getLogger(VariantSourceStats.class);
+            logger.warn("{} VariantStats have needed members as null", incompleteVariantStats);
         }
     }
         

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantStats.java
@@ -105,7 +105,7 @@ public class VariantStats {
         return refAllele;
     }
 
-    void setRefAllele(String refAllele) {
+    public void setRefAllele(String refAllele) {
         this.refAllele = refAllele;
     }
 
@@ -113,7 +113,7 @@ public class VariantStats {
         return altAllele;
     }
 
-    void setAltAllele(String altAllele) {
+    public void setAltAllele(String altAllele) {
         this.altAllele = altAllele;
     }
 
@@ -121,7 +121,7 @@ public class VariantStats {
         return variantType;
     }
 
-    void setVariantType(Variant.VariantType variantType) {
+    public void setVariantType(Variant.VariantType variantType) {
         this.variantType = variantType;
     }
 


### PR DESCRIPTION
VariantGlobalStats may be incorrect if VariantStats has some null
values. This log will be deleted when the issue is fixed.

related to https://github.com/opencb/biodata/issues/30