### PR TITLE
GtfReader, AbstractFormatReader: added 'implements AutoCloseable' clause

### DIFF
--- a/biodata-formats/src/main/java/org/opencb/biodata/formats/feature/gtf/io/GtfReader.java
+++ b/biodata-formats/src/main/java/org/opencb/biodata/formats/feature/gtf/io/GtfReader.java
@@ -14,7 +14,7 @@ import org.opencb.biodata.formats.io.FileFormatException;
 import org.opencb.commons.utils.FileUtils;
 
 
-public class GtfReader {
+public class GtfReader implements AutoCloseable {
 
     private BufferedReader bufferedReader;
     private File file;

--- a/biodata-formats/src/main/java/org/opencb/biodata/formats/io/AbstractFormatReader.java
+++ b/biodata-formats/src/main/java/org/opencb/biodata/formats/io/AbstractFormatReader.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public abstract class AbstractFormatReader<T> {
+public abstract class AbstractFormatReader<T> implements AutoCloseable {
 
     protected Path path;
     protected Logger logger;


### PR DESCRIPTION
Added 'implements AutoCloseable' clause to some readers, so they can be built inside try-with-resources statements