### PR TITLE
models: bugfix making the default cohort coherent in all places.

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantSourceEntry.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantSourceEntry.java
@@ -47,7 +47,7 @@ public class VariantSourceEntry {
      * or its minimum allele frequency, grouped by cohort name.
      */
     private Map<String, VariantStats> cohortStats;
-    public static final String DEFAULT_COHORT = "all";
+    public static final String DEFAULT_COHORT = "ALL";
     
     /**
      * Optional attributes that probably depend on the format of the file the


### PR DESCRIPTION
Cohort names are case sensitive. Recommended practice is to write cohorts (at the mapping files) in UPPER CASE to match the default cohort that includes all samples.