### PR TITLE
models:stats: fixed bug when a parsed genotype is "."

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantSourceStats.java
@@ -115,7 +115,7 @@ public class VariantSourceStats {
 //                }
                 
                 // Count homozygous (not haploid)
-                if (g.getCode() != AllelesCode.HAPLOID && g.getAllele(0) == g.getAllele(1)) {
+                if (g.getAllelesIdx().length > 1 && g.getAllele(0) == g.getAllele(1)) {
                     sampleStats.incrementHomozygous();
                 }
             }

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantStats.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/stats/VariantStats.java
@@ -423,21 +423,15 @@ public class VariantStats {
                 default:
                     // Missing genotype (one or both alleles missing)
                     this.setMissingGenotypes(this.getMissingGenotypes() + 1);
-                    if (g.getAllele(0) < 0) {
-                        this.setMissingAlleles(this.getMissingAlleles() + 1);
-                    } else {
-                        allelesCount[g.getAllele(0)]++;
-                        totalAllelesCount++;
-                    }
-
-                    if (g.getAllele(1) < 0) {
-                        this.setMissingAlleles(this.getMissingAlleles() + 1);
-                    } else {
-                        allelesCount[g.getAllele(1)]++;
-                        totalAllelesCount++;
+                    for (int i = 0; i < g.getAllelesIdx().length; i++) {
+                        if (g.getAllele(i) < 0) {
+                            this.setMissingAlleles(this.getMissingAlleles() + 1);
+                        } else {
+                            allelesCount[g.getAllele(i)]++;
+                            totalAllelesCount++;
+                        }
                     }
                     break;
-
             }
 
             // Include statistics that depend on pedigree information

--- a/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
+++ b/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
@@ -2,11 +2,13 @@ package org.opencb.biodata.models.variant;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opencb.biodata.models.variant.exceptions.NotAVariantException;
 
 import java.util.*;
 import static org.junit.Assert.assertArrayEquals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
@@ -60,11 +62,17 @@ public class VariantVcfFactoryTest {
     public void testCreateVariantFromVcfDeletionEmptyAlt() {
         String line = "1\t1000\trs123\tTCACCC\t.\t.\t.\t.";
 
-        List<Variant> expResult = new LinkedList<>();
-        expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
+//        if this were not considered as a bad input
+//        List<Variant> expResult = new LinkedList<>();
+//        expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
+//        assertEquals(expResult, result);
 
-        List<Variant> result = factory.create(source, line);
-        assertEquals(expResult, result);
+        try {
+            List<Variant> result = factory.create(source, line);
+            fail();
+        } catch (NotAVariantException e) {
+            return;
+        }
     }
 
     @Test
@@ -82,7 +90,7 @@ public class VariantVcfFactoryTest {
         result = factory.create(source, line);
         assertEquals(expResult, result);
         
-        line = "1\t1000\trs123\tATC\t.\t.\t.\t.";
+        line = "1\t1000\trs123\tATC\t\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1002, "ATC", ""));
         result = factory.create(source, line);

--- a/biodata-models/src/test/java/org/opencb/biodata/models/variant/stats/VariantStatsTest.java
+++ b/biodata-models/src/test/java/org/opencb/biodata/models/variant/stats/VariantStatsTest.java
@@ -20,10 +20,29 @@ public class VariantStatsTest {
     private VariantSource source = new VariantSource("filename.vcf", "fileId", "studyId", "studyName");
 
     @Test
-    public void testCalculateBiallelicStats() {
+    public void testCalculateOtherStats() {
         List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005", "NA006");
         source.setSamples(sampleNames);
         String line = "1\t10040\trs123\tT\tC\t10.05\tHELLO\t.\tGT:GL\t"
+                + "0/0\t.\t./.\t0/0\t0/-1\t./0"; // 6 samples
+
+        // Initialize expected variants
+        List<Variant> result = new VariantVcfFactory().create(source, line);
+        assertEquals(1, result.size());
+
+        Variant variant = result.get(0);
+        VariantSourceEntry sourceEntry = variant.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        VariantStats stats = new VariantStats(variant).calculate(sourceEntry.getSamplesData(), sourceEntry.getAttributes(), null);
+        assertEquals(5, stats.getMissingAlleles());
+        assertEquals(4, stats.getMissingGenotypes());
+    }
+
+    @Test
+    public void testCalculateBiallelicStats() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005", "NA006");
+        source.setSamples(sampleNames);
+        String line = "1\t10040\trs123\tT\tC\t10.05\tHELLO\t.\tGT\t"
                 + "0/0:1,2,3,4,5,6,7,8,9,10\t0/1:1,2,3,4,5,6,7,8,9,10\t0/1:1,2,3,4,5,6,7,8,9,10\t"
                 + "1/1:1,2,3,4,5,6,7,8,9,10\t./.:1,2,3,4,5,6,7,8,9,10\t1/1:1,2,3,4,5,6,7,8,9,10"; // 6 samples
 


### PR DESCRIPTION
if a genotype is "." or "-1", it means it's a missing single allele in an
haploid genotype.
