### PR TITLE
models: fixed conflict tests in VariantVcfFactory

### DIFF
--- a/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
+++ b/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
@@ -18,11 +18,13 @@ package org.opencb.biodata.models.variant;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opencb.biodata.models.variant.exceptions.NotAVariantException;
 
 import java.util.*;
 import static org.junit.Assert.assertArrayEquals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
@@ -74,13 +76,14 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfDeletionEmptyAlt() {
-        String line = "1\t1000\trs123\tTCACCC\t.\t.\t.\t.";
 
-        List<Variant> expResult = new LinkedList<>();
-        expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
-
-//        List<Variant> result = factory.create(source, line);
-//        assertEquals(expResult, result);
+        try {
+            String line = "1\t1000\trs123\tTCACCC\t.\t.\t.\t.";
+            List<Variant> result = factory.create(source, line);
+            fail();
+        } catch (NotAVariantException e) {
+            // expected exception. continue.
+        }
     }
 
     @Test
@@ -98,11 +101,13 @@ public class VariantVcfFactoryTest {
         result = factory.create(source, line);
         assertEquals(expResult, result);
         
-//        line = "1\t1000\trs123\tATC\t.\t.\t.\t.";
-//        expResult = new LinkedList<>();
-//        expResult.add(new Variant("1", 1000, 1002, "ATC", ""));
-//        result = factory.create(source, line);
-//        assertEquals(expResult, result);
+        try {
+            line = "1\t1000\trs123\tGATC\t.\t.\t.\t.";
+            result = factory.create(source, line);
+            fail();
+        } catch (NotAVariantException e) {
+            // expected exception. continue.
+        }
         
         line = "1\t1000\trs123\t.\tATC\t.\t.\t.";
         expResult = new LinkedList<>();


### PR DESCRIPTION
[`NotAVariantException`](https://github.com/opencb/biodata/blob/develop/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantVcfFactory.java#L57) is expected when a "." is present in the ALT field.