### PR TITLE
models: changed policy of "." variant ids. now they are not stored.

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantVcfFactory.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantVcfFactory.java
@@ -42,8 +42,12 @@ public class VariantVcfFactory implements VariantFactory {
 
         String chromosome = fields[0];
         int position = Integer.parseInt(fields[1]);
-        String id = fields[2].equals(".") ? "" : fields[2];
-        Set<String> ids = new HashSet<>(Arrays.asList(id.split(";")));
+
+        Set<String> ids = new HashSet<>();
+        if (!fields[2].equals(".")) {    // note!: we store a "." as an empty set, not a set with an empty string
+            ids.addAll(Arrays.asList(fields[2].split(";")));
+        }
+
         String reference = fields[3].equals(".") ? "" : fields[3];
         String alternate = fields[4];
         if(fields[4].equals(".")) {
@@ -323,9 +327,8 @@ public class VariantVcfFactory implements VariantFactory {
     protected void setOtherFields(Variant variant, VariantSource source, Set<String> ids, float quality, String filter,
             String info, String format, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
-        if (!ids.isEmpty()) {
-            variant.setIds(ids);
-        }
+        variant.setIds(ids);
+
         if (quality > -1) {
             variant.getSourceEntry(source.getFileId(), source.getStudyId()).addAttribute("QUAL", String.valueOf(quality));
         }

--- a/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
+++ b/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
@@ -533,7 +533,9 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void testCreateVariantWithEmptyIds() {
+    public void testVariantIds() {
+
+        // test that an ID is properly handled
         String line = "1\t1000\trs123\tC\tT\t.\t.\t.";
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
@@ -542,6 +544,7 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
         assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
 
+        // test that the ';' is used as the ID separator (as of VCF 4.2)
         line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
@@ -550,7 +553,7 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
         assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
 
-
+        // test that a missing ID ('.') is not added to the IDs set
         line = "1\t1000\t.\tC\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));

--- a/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
+++ b/biodata-models/src/test/java/org/opencb/biodata/models/variant/VariantVcfFactoryTest.java
@@ -531,5 +531,32 @@ public class VariantVcfFactoryTest {
         assertEquals(10685, Integer.parseInt(getFile1.getAttribute("MQ")));
         assertEquals(1, Integer.parseInt(getFile1.getAttribute("MQ0")));
     }
-    
+
+    @Test
+    public void testCreateVariantWithEmptyIds() {
+        String line = "1\t1000\trs123\tC\tT\t.\t.\t.";
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(Collections.singleton("rs123"));
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
+
+        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(new HashSet<>(Arrays.asList("rs123", "rs456")));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
+
+
+        line = "1\t1000\t.\tC\tT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(Collections.<String>emptySet());    // note!: we store a "." as an empty set, not a set with an empty string
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds().size(), result.get(0).getIds().size());
+    }
 }


### PR DESCRIPTION
Before, they were stored as "", i.e. an empty string in the `ids` set.