### PR TITLE
adding assembly to evidence model

### DIFF
--- a/biodata-models/src/main/avro/evidence.avdl
+++ b/biodata-models/src/main/avro/evidence.avdl
@@ -454,6 +454,10 @@ Evidence of benign impact:
         */
         union {null, string} id;
         /**
+        The reference genome assembly
+        */
+        union {null, string} assembly;
+        /**
         List of allele origins
         */
         union {null, array<AlleleOrigin>} alleleOrigin;


### PR DESCRIPTION
Adding a nullable assembly field to the evidence model. This will be required in CVA to support multiple assemblies.
@javild 