### PR TITLE
fix-mnv-protein-level-clinical-search: bugfix. Attributes now initial…

### DIFF
--- a/biodata-formats/pom.xml
+++ b/biodata-formats/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-models/pom.xml
+++ b/biodata-models/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-tools/pom.xml
+++ b/biodata-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
+++ b/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
@@ -323,7 +323,7 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
                         studyEntry.setFormat(Collections.singletonList("PS"));
                         // Use mnv string as file Id so that it can be later identified. It is also used
                         // as the genotype call since we don't have an actual call and to avoid confusion
-                        studyEntry.setFiles(Collections.singletonList(new FileEntry(keyFields.getPhaseSet(), call, null)));
+                        studyEntry.setFiles(Collections.singletonList(new FileEntry(keyFields.getPhaseSet(), call, new HashMap<>())));
                         normalizedVariant.setStudies(Collections.singletonList(studyEntry));
                     }
                     normalizedVariants.add(normalizedVariant);
@@ -462,7 +462,7 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
                                 // for all mnv-phased variants
                                 if (normalizedEntry.getFiles().size() == 0) {
                                     // Use mnv string as file Id so that it can be later identified.
-                                    normalizedEntry.setFiles(Collections.singletonList(new FileEntry(keyFields.getPhaseSet(), call, null)));
+                                    normalizedEntry.setFiles(Collections.singletonList(new FileEntry(keyFields.getPhaseSet(), call, new HashMap<>())));
                                 }
                             }
                             List<List<String>> normalizedSamplesData = normalizeSamplesData(keyFields,

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.opencb.biodata</groupId>
     <artifactId>biodata</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Biodata</name>
@@ -34,7 +34,7 @@
     </modules>
 
     <properties>
-        <biodata.version>1.5.2</biodata.version>
+        <biodata.version>1.5.3-SNAPSHOT</biodata.version>
         <compileSource>1.8</compileSource>
         <commons.version>3.7.3</commons.version>
         <ga4gh.version>0.6.0a5</ga4gh.version>


### PR DESCRIPTION
…ised to empty HashMap instead of null. Prevents failure during double normalisation of decomposed MNVs