### PR TITLE
Hotfix 1.5.x - fix MNV coordinates

### DIFF
--- a/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
+++ b/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
@@ -954,7 +954,8 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
                     keyFields.setAlternate(keyFields.getAlternate() + alternateChar);
                 // New insertion found, create new keyFields
                 } else {
-                    keyFields = new VariantKeyFields(genomicStart + i, genomicStart + i - 1, "",
+                    int originalPosition = genomicStart + originalKeyFieldsIndex;
+                    keyFields = new VariantKeyFields(originalPosition, originalPosition - 1, "",
                             String.valueOf(alternateChar), originalKeyFields);
                     keyFieldsList.add(keyFields);
                 }

--- a/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
+++ b/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
@@ -19,7 +19,6 @@
 
 package org.opencb.biodata.tools.variant;
 
-import htsjdk.samtools.SAMException;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.vcf.*;
 import org.apache.commons.lang3.ArrayUtils;
@@ -934,10 +933,15 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
         VariantKeyFields keyFields = null;
         char previousReferenceChar = 0;
         char previousAlternateChar = 0;
+        int originalKeyFieldsIndex = 0;
         // Assume that as a result of the alignment "reference" and "alternate" Strings are of the same length
         for (int i = 0; i < reference.length(); i++) {
             char referenceChar = reference.charAt(i);
             char alternateChar = alternate.charAt(i);
+            if (referenceChar != '-') {
+                // keep track where we are in the original reference
+                originalKeyFieldsIndex++;
+            }
             // Insertion
             if (referenceChar == '-') {
                 // Assume there cannot be a '-' at the reference and alternate aligned sequences at the same position
@@ -959,16 +963,18 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
                 // Current character is a continuation of a deletion
                 if (previousAlternateChar == '-') {
                     keyFields.setReference(keyFields.getReference() + referenceChar);
-                    keyFields.setEnd(keyFields.getEnd()+1);
+                    keyFields.setEnd(keyFields.getEnd() + 1);
                 // New deletion found, create new keyFields
                 } else {
-                    keyFields = new VariantKeyFields(genomicStart + i, genomicStart + i,
+                    int originalPosition = genomicStart + originalKeyFieldsIndex - 1;
+                    keyFields = new VariantKeyFields(originalPosition, originalPosition,
                             String.valueOf(referenceChar),"", originalKeyFields);
                     keyFieldsList.add(keyFields);
                 }
             // SNV
             } else if (referenceChar != alternateChar) {
-                keyFields = new VariantKeyFields(genomicStart + i, genomicStart + i,
+                int originalPosition = genomicStart + originalKeyFieldsIndex - 1;
+                keyFields = new VariantKeyFields(originalPosition, originalPosition,
                         String.valueOf(referenceChar), String.valueOf(alternateChar), originalKeyFields);
                 keyFieldsList.add(keyFields);
             }

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -106,6 +106,189 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
     }
 
     @Test
+    public void testMNVInsertion() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+        // clinvar ID 266834
+        // chr13:32316508:GAC:ATCGATCGAT
+        // chr13:32316508:G:ATCGATCG
+        // chr13:32316510:C:T
+        Variant variant = new Variant("13:32316508:GAC:ATCGATCGAT");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32316508), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("ATCGATC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32316510), normalizedVariant.getStart());
+        assertEquals("C", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
+// clinvar ID 233410
+//        chr2:47800055:TCAA:ATTAAA
+//        chr2:47800055:T:ATT
+//        chr2:47800056:C:A
+
+        variant = new Variant("2:47800055:TCAA:ATTAAA");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(47800055), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("AT", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(47800056), normalizedVariant.getStart());
+        assertEquals("C", normalizedVariant.getReference());
+        assertEquals("A", normalizedVariant.getAlternate());
+
+    }
+
+    @Test
+    public void testMVNDoubleDeletions() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+// clinvar ID 17618
+//        chr15:42410982:AG:TCATCT
+//        chr15:42410981:T:TTC
+//        chr15:42410982:A:ATC
+//        chr15:42410983:G:T
+
+        Variant variant = new Variant("15:42410982:AG:TCATCT");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(3, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410983), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410985), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TC", normalizedVariant.getAlternate());
+    }
+
+    // clinvar ID 266834
+    @Test
+    public void testNoVCV() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+//        chr13:32316508:GAC:ATCGATCGAT
+//        chr13:32316508:G:ATCGATCG
+//        chr13:32316510:C:T
+
+        Variant variant = new Variant("13:32316508:GAC:ATCGATCGAT");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(3, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410983), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410985), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TC", normalizedVariant.getAlternate());
+
+
+    }
+
+
+    @Test
+    public void testMVNDeletions() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+//        chr1:5927667:GTT:CCACG
+//        chr1:5927666:G:CCAC
+//        chr1:5927667:GTT:G
+
+        Variant variant = new Variant("1:5927667:GTT:CCACG");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("1", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(5927667), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("CCAC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("1", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(5927668), normalizedVariant.getStart());
+        assertEquals("TT", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+    }
+
+
+    @Test
     public void testNormalizeSamplesDataMNV() throws NonStandardCompliantSampleField {
         normalizer.setDecomposeMNVs(true);
         Variant variant = newVariant(100, "ACTCGTAAA", "ATTCGAAA");

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -241,29 +241,16 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals("C", normalizedVariant.getReference());
         assertEquals("T", normalizedVariant.getAlternate());
 
-    }
-
-    // clinvar ID 438988
-    @Test
-    public void testWrongId2() {
-
-        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
-                = (new VariantNormalizer.VariantNormalizerConfig())
-                .setReuseVariants(true)
-                .setNormalizeAlleles(true)
-                .setDecomposeMNVs(true);
-
-        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
 
 // chr13:32339556:AAAAA:GAAAAG
 //
 //chr13:32339555:G:GG//
 //chr13:32339560:A:G
-        Variant variant = new Variant("13:32339556:AAAAA:GAAAAG");
-        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        variant = new Variant("13:32339556:AAAAA:GAAAAG");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
         assertEquals(2, normalizedVariantList.size());
 
-        Variant normalizedVariant = normalizedVariantList.get(0);
+        normalizedVariant = normalizedVariantList.get(0);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("13", normalizedVariant.getChromosome());
         assertEquals(Integer.valueOf(32339556), normalizedVariant.getStart());
@@ -276,6 +263,53 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals(Integer.valueOf(32339560), normalizedVariant.getStart());
         assertEquals("A", normalizedVariant.getReference());
         assertEquals("G", normalizedVariant.getAlternate());
+
+
+        //125928	chr13:32332369:AACAGTTGT:GATACTTCAG
+//        chr13:32332369:A:G
+//        chr13:32332371:C:T
+//        chr13:32332373:G:C
+//        chr13:32332375:T:TCA
+//        chr13:32332376:GT:G
+
+        variant = new Variant("13:32332369:AACAGTTGT:GATACTTCAG");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(5, normalizedVariantList.size());
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32332369), normalizedVariant.getStart());
+        assertEquals("A", normalizedVariant.getReference());
+        assertEquals("G", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32332371), normalizedVariant.getStart());
+        assertEquals("C", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32332373), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("C", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(3);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32332376), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("CA", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(4);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32332377), normalizedVariant.getStart());
+        assertEquals("T", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
 
     }
 
@@ -314,6 +348,94 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
 
     }
 
+    @Test
+    public void testNoVcv() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+//        407332	chr11:47351272:TGG:CCTCC
+//        chr11:47351272:T:CCT
+//        chr11:47351273:G:C
+//        chr11:47351274:G:C
+
+        Variant variant = new Variant("11:47351272:TGG:CCTCC");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(3, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("11", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(47351272), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("CC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("11", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(47351273), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("C", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("11", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(47351274), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("C", normalizedVariant.getAlternate());
+
+        // 419158
+        variant = new Variant("chr2:108907934:AGCCCTG:CGGGCTCCTCATCA");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(5, normalizedVariantList.size());
+
+//        chr2:108907934:A:C
+//        chr2:108907935:G:GGG
+//        chr2:108907936:C:CT
+//        chr2:108907939:T:TCATC
+//        chr2:108907940:G:A
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(108907934), normalizedVariant.getStart());
+        assertEquals("A", normalizedVariant.getReference());
+        assertEquals("C", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(108907936), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("GG", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(108907937), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(3);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(108907940), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("CATC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(4);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("2", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(108907940), normalizedVariant.getStart());
+        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("A", normalizedVariant.getAlternate());
+
+    }
 
     @Test
     public void testNormalizeSamplesDataMNV() throws NonStandardCompliantSampleField {

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -207,7 +207,7 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals("T", normalizedVariant.getAlternate());
     }
 
-    // clinvar ID 266834
+
     @Test
     public void testWrongId() {
 
@@ -218,7 +218,7 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
                 .setDecomposeMNVs(true);
 
         VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
-
+        // clinvar ID 266834
 //        chr13:32316508:GAC:ATCGATCGAT
 //        chr13:32316508:G:ATCGATCG
 //        chr13:32316510:C:T
@@ -311,6 +311,30 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals("T", normalizedVariant.getReference());
         assertEquals("", normalizedVariant.getAlternate());
 
+
+        //clinvarID 584850
+
+//        chr13:32336521:AAG:A
+//        chr13:32336524:C:CT
+
+        variant = new Variant("13:32336522:AGC:CT");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32336522), normalizedVariant.getStart());
+        assertEquals("AG", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32336525), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("T", normalizedVariant.getAlternate());
+
     }
 
     @Test
@@ -390,7 +414,7 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals("C", normalizedVariant.getAlternate());
 
         // 419158
-        variant = new Variant("chr2:108907934:AGCCCTG:CGGGCTCCTCATCA");
+        variant = new Variant("2:108907934:AGCCCTG:CGGGCTCCTCATCA");
         normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
         assertEquals(5, normalizedVariantList.size());
 
@@ -434,6 +458,67 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals(Integer.valueOf(108907940), normalizedVariant.getStart());
         assertEquals("G", normalizedVariant.getReference());
         assertEquals("A", normalizedVariant.getAlternate());
+
+
+        // 141142
+        variant = new Variant("17:43063370:ACCCCTAAAGAGATCATAGA:TATT");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(4, normalizedVariantList.size());
+
+//        chr17:43063369:CACCCC:C
+//        chr17:43063375:TAAAGAG:T
+//        chr17:43063383:TCA:T
+//        chr17:43063386:TAGA:T
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("17", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(43063370), normalizedVariant.getStart());
+        assertEquals("ACCCC", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("17", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(43063376), normalizedVariant.getStart());
+        assertEquals("AAAGAG", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("17", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(43063384), normalizedVariant.getStart());
+        assertEquals("CA", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(3);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("17", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(43063387), normalizedVariant.getStart());
+        assertEquals("AGA", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        // ClinVarID 90202
+        variant = new Variant("3:37006995:AG:GTT");
+        normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+//        chr3:37006994:AA:A
+//        chr3:37006996:G:GTT
+
+        normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("3", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(37006995), normalizedVariant.getStart());
+        assertEquals("A", normalizedVariant.getReference());
+        assertEquals("", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("3", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(37006997), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TT", normalizedVariant.getAlternate());
 
     }
 

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -188,14 +188,14 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
 
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410981), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
         assertEquals("", normalizedVariant.getReference());
         assertEquals("TC", normalizedVariant.getAlternate());
 
         normalizedVariant = normalizedVariantList.get(1);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(42410983), normalizedVariant.getStart());
         assertEquals("", normalizedVariant.getReference());
         assertEquals("TC", normalizedVariant.getAlternate());
 
@@ -266,7 +266,7 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         Variant normalizedVariant = normalizedVariantList.get(0);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("13", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(32339555), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(32339556), normalizedVariant.getStart());
         assertEquals("", normalizedVariant.getReference());
         assertEquals("G", normalizedVariant.getAlternate());
 
@@ -299,16 +299,16 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals(2, normalizedVariantList.size());
 
         Variant normalizedVariant = normalizedVariantList.get(0);
-//        assertEquals(VariantType.INDEL, normalizedVariant.getType());
-//        assertEquals("1", normalizedVariant.getChromosome());
-//        assertEquals(Integer.valueOf(5927666), normalizedVariant.getStart());
-//        assertEquals("", normalizedVariant.getReference());
-//        assertEquals("CCAC", normalizedVariant.getAlternate());
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("1", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(5927667), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("CCAC", normalizedVariant.getAlternate());
 
         normalizedVariant = normalizedVariantList.get(1);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("1", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(5927667), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(5927668), normalizedVariant.getStart());
         assertEquals("TT", normalizedVariant.getReference());
         assertEquals("", normalizedVariant.getAlternate());
 

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -188,28 +188,28 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
 
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(42410981), normalizedVariant.getStart());
         assertEquals("", normalizedVariant.getReference());
         assertEquals("TC", normalizedVariant.getAlternate());
 
         normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("15", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("TC", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(2);
         assertEquals(VariantType.SNV, normalizedVariant.getType());
         assertEquals("15", normalizedVariant.getChromosome());
         assertEquals(Integer.valueOf(42410983), normalizedVariant.getStart());
         assertEquals("G", normalizedVariant.getReference());
         assertEquals("T", normalizedVariant.getAlternate());
-
-        normalizedVariant = normalizedVariantList.get(2);
-        assertEquals(VariantType.INDEL, normalizedVariant.getType());
-        assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410985), normalizedVariant.getStart());
-        assertEquals("", normalizedVariant.getReference());
-        assertEquals("TC", normalizedVariant.getAlternate());
     }
 
     // clinvar ID 266834
     @Test
-    public void testNoVCV() {
+    public void testWrongId() {
 
         VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
                 = (new VariantNormalizer.VariantNormalizerConfig())
@@ -225,32 +225,59 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
 
         Variant variant = new Variant("13:32316508:GAC:ATCGATCGAT");
         List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
-        assertEquals(3, normalizedVariantList.size());
+        assertEquals(2, normalizedVariantList.size());
 
         Variant normalizedVariant = normalizedVariantList.get(0);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
-        assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410982), normalizedVariant.getStart());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32316508), normalizedVariant.getStart());
         assertEquals("", normalizedVariant.getReference());
-        assertEquals("TC", normalizedVariant.getAlternate());
+        assertEquals("ATCGATC", normalizedVariant.getAlternate());
 
         normalizedVariant = normalizedVariantList.get(1);
         assertEquals(VariantType.SNV, normalizedVariant.getType());
-        assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410983), normalizedVariant.getStart());
-        assertEquals("G", normalizedVariant.getReference());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32316510), normalizedVariant.getStart());
+        assertEquals("C", normalizedVariant.getReference());
         assertEquals("T", normalizedVariant.getAlternate());
-
-        normalizedVariant = normalizedVariantList.get(2);
-        assertEquals(VariantType.INDEL, normalizedVariant.getType());
-        assertEquals("15", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(42410985), normalizedVariant.getStart());
-        assertEquals("", normalizedVariant.getReference());
-        assertEquals("TC", normalizedVariant.getAlternate());
-
 
     }
 
+    // clinvar ID 438988
+    @Test
+    public void testWrongId2() {
+
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setReuseVariants(true)
+                .setNormalizeAlleles(true)
+                .setDecomposeMNVs(true);
+
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+
+// chr13:32339556:AAAAA:GAAAAG
+//
+//chr13:32339555:G:GG//
+//chr13:32339560:A:G
+        Variant variant = new Variant("13:32339556:AAAAA:GAAAAG");
+        List<Variant> normalizedVariantList = variantNormalizer.apply(Collections.singletonList(variant));
+        assertEquals(2, normalizedVariantList.size());
+
+        Variant normalizedVariant = normalizedVariantList.get(0);
+        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32339555), normalizedVariant.getStart());
+        assertEquals("", normalizedVariant.getReference());
+        assertEquals("G", normalizedVariant.getAlternate());
+
+        normalizedVariant = normalizedVariantList.get(1);
+        assertEquals(VariantType.SNV, normalizedVariant.getType());
+        assertEquals("13", normalizedVariant.getChromosome());
+        assertEquals(Integer.valueOf(32339560), normalizedVariant.getStart());
+        assertEquals("A", normalizedVariant.getReference());
+        assertEquals("G", normalizedVariant.getAlternate());
+
+    }
 
     @Test
     public void testMVNDeletions() {
@@ -272,16 +299,16 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
         assertEquals(2, normalizedVariantList.size());
 
         Variant normalizedVariant = normalizedVariantList.get(0);
-        assertEquals(VariantType.INDEL, normalizedVariant.getType());
-        assertEquals("1", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(5927667), normalizedVariant.getStart());
-        assertEquals("", normalizedVariant.getReference());
-        assertEquals("CCAC", normalizedVariant.getAlternate());
+//        assertEquals(VariantType.INDEL, normalizedVariant.getType());
+//        assertEquals("1", normalizedVariant.getChromosome());
+//        assertEquals(Integer.valueOf(5927666), normalizedVariant.getStart());
+//        assertEquals("", normalizedVariant.getReference());
+//        assertEquals("CCAC", normalizedVariant.getAlternate());
 
         normalizedVariant = normalizedVariantList.get(1);
         assertEquals(VariantType.INDEL, normalizedVariant.getType());
         assertEquals("1", normalizedVariant.getChromosome());
-        assertEquals(Integer.valueOf(5927668), normalizedVariant.getStart());
+        assertEquals(Integer.valueOf(5927667), normalizedVariant.getStart());
         assertEquals("TT", normalizedVariant.getReference());
         assertEquals("", normalizedVariant.getAlternate());
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,15 @@
         <commons.version>3.7.5-SNAPSHOT</commons.version>
         <ga4gh.version>0.6.0a5</ga4gh.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.25</slf4j.version>
+        <log4j2.version>2.13.3</log4j2.version>
         <avro.version>1.7.7</avro.version>
         <protobuf.version>3.5.1</protobuf.version>
         <grpc.version>1.9.1</grpc.version>
         <!--<htsjdk.version>2.6.1</htsjdk.version>-->
         <htsjdk.version>2.16.0</htsjdk.version>
         <sqlite.version>3.15.1</sqlite.version>
+
     </properties>
 
     <scm>
@@ -150,12 +153,26 @@
                 <artifactId>ga4gh</artifactId>
                 <version>${ga4gh.version}</version>
             </dependency>
-                    <dependency>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-lang3</artifactId>
-                        <version>3.4</version>
-                    </dependency>
-
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.samtools</groupId>
                 <artifactId>htsjdk</artifactId>


### PR DESCRIPTION
The MNV positions were incorrect. Here's an example:

ClinVar ID: 266834 
chr13:32316508:GAC:ATCGATCGAT

**Decomposed variants**

Dragen | CellBase output
------------ | -------------
13:32316508:G:ATCGATCG | 13:32316508::ATCGATC
13:32316510:C:T | 13:32316517:C:T << wrong

The coordinates are calculated with the start, and the index:

`genomic start` + `current index` = `start`

Previously the code was using the index for the right aligned string, which was **"-------GAC"**

32316508 + 9 (index of **-------GAC**) = 32316517 << incorrect

I've updated the code to use the index of the original **"GAC"** 

32316508 + 2 (index of **GAC**) = 32316510 << correct
