### PR TITLE
remove VUS, it's a duplicate of uncertain significance

### DIFF
--- a/biodata-models/src/main/avro/evidence.avdl
+++ b/biodata-models/src/main/avro/evidence.avdl
@@ -157,7 +157,6 @@ conflicting evidences should be classified as uncertain_significance
     enum ClinicalSignificance {
         benign,
         likely_benign,
-        VUS,
         likely_pathogenic,
         pathogenic,
         uncertain_significance


### PR DESCRIPTION
This query: https://ws.zettagenomics.com/cellbase/webservices/rest/v5/hsapiens/clinical/variant/clinsigLabels

returns the labels in `evidence.avdl`, It returns `VUS` however `VUS` means the same thing as "uncertain_significance" so this is a duplication.

In the clinvar parser, variants with the VUS signficance are discarded. I've updated this in v4 (and will make a PR for v5) to parse VUS variants as "uncertain_significance"

But I need this duplicate removed first.It's not a valid label to search on.