### PR TITLE
spanning deletion normalization error

### DIFF
--- a/biodata-formats/pom.xml
+++ b/biodata-formats/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-models/pom.xml
+++ b/biodata-models/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -44,7 +44,7 @@ public class Variant implements Serializable, Comparable<Variant> {
 
     public static final int SV_THRESHOLD = 50;
     public static final int UNKNOWN_LENGTH = 0;
-    public static final String SPANNING_DELETION = "*"; // Ref allele of a deletion that spans a position of interest
+    public static final String SPANNING_DELETION = "*"; // Alt allele of a deletion that spans a position of interest
     public Variant() {
         impl = new VariantAvro(null, new LinkedList<>(), "", -1, -1, "", "", "+", null, 0, null, new HashMap<>(), new LinkedList<>(), null);
     }

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -44,7 +44,7 @@ public class Variant implements Serializable, Comparable<Variant> {
 
     public static final int SV_THRESHOLD = 50;
     public static final int UNKNOWN_LENGTH = 0;
-
+    public static final String SPANNING_DELETION = "*"; // Ref allele of a deletion that spans a position of interest
     public Variant() {
         impl = new VariantAvro(null, new LinkedList<>(), "", -1, -1, "", "", "+", null, 0, null, new HashMap<>(), new LinkedList<>(), null);
     }
@@ -165,6 +165,8 @@ public class Variant implements Serializable, Comparable<Variant> {
     public boolean isSymbolic() {
         return Allele.wouldBeSymbolicAllele(getAlternate().getBytes());
     }
+
+    public boolean isSpanningDeletion() { return getAlternate().equals(SPANNING_DELETION); }
 
     public VariantAvro getImpl() {
         return impl;

--- a/biodata-tools/pom.xml
+++ b/biodata-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.biodata</groupId>
         <artifactId>biodata</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
+++ b/biodata-tools/src/main/java/org/opencb/biodata/tools/variant/VariantNormalizer.java
@@ -1012,7 +1012,9 @@ public class VariantNormalizer implements ParallelTaskRunner.Task<Variant, Varia
      * Non normalizable variants
      */
     private boolean isNormalizable(Variant variant) {
-        return !variant.getType().equals(VariantType.NO_VARIATION) && !variant.getType().equals(VariantType.SYMBOLIC);
+        return !variant.getType().equals(VariantType.NO_VARIATION)
+                && !variant.getType().equals(VariantType.SYMBOLIC)
+                && !variant.isSpanningDeletion();
     }
 
     protected VariantKeyFields createVariantsFromInsertionEmptyRef(int position, String alt) {

--- a/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
+++ b/biodata-tools/src/test/java/org/opencb/biodata/tools/variant/VariantNormalizerTest.java
@@ -91,6 +91,17 @@ public class VariantNormalizerTest extends VariantNormalizerGenericTest {
     }
 
     @Test
+    public void testNormalizeSpanningDeletionWithDecomposeDoesNotRaiseError() throws NonStandardCompliantSampleField {
+        Variant variant = new Variant("13:32316508:GCCCC:*");
+        VariantNormalizer.VariantNormalizerConfig variantNormalizerConfig
+                = (new VariantNormalizer.VariantNormalizerConfig())
+                .setDecomposeMNVs(true);
+        VariantNormalizer variantNormalizer = new VariantNormalizer(variantNormalizerConfig);
+        List<Variant> normalizedVariantList = variantNormalizer.normalize(Collections.singletonList(variant), false);
+        assertEquals(variant, normalizedVariantList.get(0));
+    }
+
+    @Test
     public void testNormalizeFalseMNV() throws NonStandardCompliantSampleField {
 
         Variant variant = newVariant(100, "CA", "TA");

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.opencb.biodata</groupId>
     <artifactId>biodata</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
     <packaging>pom</packaging>
 
     <name>Biodata</name>
@@ -34,7 +34,7 @@
     </modules>
 
     <properties>
-        <biodata.version>1.5.6</biodata.version>
+        <biodata.version>1.5.7</biodata.version>
         <compileSource>1.8</compileSource>
         <commons.version>3.7.5</commons.version>
         <ga4gh.version>0.6.0a5</ga4gh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <repositories>
         <repository>
             <id>opencb-ext-libs</id>
-            <url>http://bioinfo.hpc.cam.ac.uk/downloads/ext-libs/</url>
+            <url>https://app.opencb.org/downloads/ext-libs/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Spanning deletion variants cause an error when passed in with a batch of variants to the normalize method with decompose=true e.g `1:100:GCCC:*`:

`Error when creating DNASequence objects for GCCC and * prior to pairwise sequence alignment`

This here is fixed by checking spanning deletions and not normalizing them